### PR TITLE
feat: rename proxy.ts to host.ts and add example in dev-server proxy

### DIFF
--- a/src/config/host.ts
+++ b/src/config/host.ts
@@ -1,20 +1,20 @@
 export default {
   development: {
     // 开发环境接口请求
-    host: 'https://service-exndqyuk-1257786608.gz.apigw.tencentcs.com',
+    API: '',
     // 开发环境 cdn 路径
-    cdn: '',
+    CDN: '',
   },
   test: {
     // 测试环境接口地址
-    host: 'https://service-exndqyuk-1257786608.gz.apigw.tencentcs.com',
+    API: 'https://service-exndqyuk-1257786608.gz.apigw.tencentcs.com',
     // 测试环境 cdn 路径
-    cdn: '',
+    CDN: '',
   },
   release: {
     // 正式环境接口地址
-    host: 'https://service-bv448zsw-1257786608.gz.apigw.tencentcs.com',
+    API: 'https://service-bv448zsw-1257786608.gz.apigw.tencentcs.com',
     // 正式环境 cdn 路径
-    cdn: '',
+    CDN: '',
   },
 };

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -1,9 +1,9 @@
 import axios from 'axios';
-import proxy from '../config/proxy';
+import proxy from '../config/host';
 
 const env = import.meta.env.MODE || 'development';
 
-const host = env === 'mock' ? '/' : proxy[env].host; // 如果是mock模式 就不配置host 会走本地Mock拦截
+const API_HOST = env === 'mock' ? '/' : proxy[env].API; // 如果是mock模式 就不配置host 会走本地Mock拦截
 
 const CODE = {
   LOGIN_TIMEOUT: 1000,
@@ -12,7 +12,7 @@ const CODE = {
 };
 
 const instance = axios.create({
-  baseURL: host,
+  baseURL: API_HOST,
   timeout: 1000,
   withCredentials: true,
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,8 +5,6 @@ import { createSvgPlugin } from 'vite-plugin-vue2-svg';
 
 import path from 'path';
 
-import proxy from './src/config/proxy';
-
 // 如有引用.env 文件，可通过下面的方法拿到变量，类似于 process.env
 // import.meta.env.VITE_SOME_KEY
 
@@ -47,7 +45,12 @@ export default defineConfig({
   server: {
     port: 3001,
     proxy: {
-      ...proxy,
+      '/api': {
+        // 用于开发环境下的转发请求
+        // 更多请参考：https://vitejs.dev/config/#server-proxy
+        target: 'https://service-exndqyuk-1257786608.gz.apigw.tencentcs.com',
+        changeOrigin: true,
+      },
     },
   },
 });


### PR DESCRIPTION
很多用户在配置网络代理的会遇到困惑。我排查了原因，我们所采用的`config/proxy.ts` 本应只配置网络请求的域名。
真正的配置应该放在 `vite.config.js`中的 proxy 字段去处理。